### PR TITLE
Do not include limits class

### DIFF
--- a/manifests/tune.pp
+++ b/manifests/tune.pp
@@ -4,8 +4,6 @@ class port389::tune {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  include 'limits'
-
   # per
   # https://access.redhat.com/site/documentation/en-US/Red_Hat_Directory_Server/9.0/html/Performance_Tuning_Guide/system-tuning.html
 

--- a/spec/classes/port389_spec.rb
+++ b/spec/classes/port389_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'port389', :type => :class do
   shared_examples 'been_tuned' do
-    it { should contain_class('limits') }
     it { should contain_sysctl('fs.file-max') }
     it { should contain_limits__limits('all_both_nofile') }
     it { should contain_limits__limits('nobody_soft_nofile') }


### PR DESCRIPTION
The limits class is not necessary to use limits::limit defined types and restricts ability to use other classes to manage limits.