### PR TITLE
replace hardcoded values by variables for enabling ssl on the admin server

### DIFF
--- a/manifests/admin/ssl.pp
+++ b/manifests/admin/ssl.pp
@@ -1,7 +1,7 @@
 # private class
 class port389::admin::ssl(
   $service_name = undef,
-  $admin_domain = undef,
+  $admin_domain = $::port389::admin_domain,
 ){
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")

--- a/manifests/admin/ssl.pp
+++ b/manifests/admin/ssl.pp
@@ -1,12 +1,14 @@
 # private class
 class port389::admin::ssl(
   $service_name = undef,
+  $admin_domain = undef,
 ){
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
   validate_string($service_name)
+  validate_string($admin_domain)
 
   Class['port389::admin::ssl'] ~> Class['port389::admin::service']
 

--- a/manifests/admin/ssl.pp
+++ b/manifests/admin/ssl.pp
@@ -1,10 +1,14 @@
 # private class
-class port389::admin::ssl {
+class port389::admin::ssl(
+  $service_name = undef,
+){
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  Class['port389::admin::ssl'] -> Class['port389::admin::service']
+  validate_string($service_name)
+
+  Class['port389::admin::ssl'] ~> Class['port389::admin::service']
 
   # per
   # http://directory.fedoraproject.org/wiki/Howto:SSL#Admin_Server_SSL_Information
@@ -39,8 +43,8 @@ class port389::admin::ssl {
   exec { 'enable_admin_ssl.ldif':
     path      => ['/bin', '/usr/bin'],
     command   => "ldapmodify ${ldap_connect} -f ${::port389::setup_dir}/enable_admin_ssl.ldif",
-    unless    => "ldapsearch ${ldap_connect} -b \"cn=slapd-ldap1,cn=389 Directory Server,cn=Server Group,\
-cn=main.vm,ou=sdm.noao.edu,o=NetscapeRoot\" nsServerSecurity nsServerSecurity | grep \"nsServerSecurity: on\"",
+    unless    => "ldapsearch ${ldap_connect} -b \"cn=slapd-${service_name},cn=389 Directory Server,cn=Server Group,\
+cn=${::port389::full_machine_name},ou=${admin_domain},o=NetscapeRoot\" nsServerSecurity nsServerSecurity | grep \"nsServerSecurity: on\"",
     logoutput => true,
     require   => [Class['openldap::client'], File['enable_admin_ssl.ldif']],
   } ->

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -141,7 +141,10 @@ It must contain only alphanumeric characters and the following: #%:@_-")
       if $::port389::enable_server_admin_ssl {
 
         Exec["setup-ds-admin.pl_${title}"] ->
-        class { 'port389::admin::ssl': service_name => $title } ->
+        class { 'port389::admin::ssl':
+          service_name => $title,
+          admin_domain => $admin_domain
+        } ->
         Class['port389::admin::service']
       }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -139,10 +139,9 @@ It must contain only alphanumeric characters and the following: #%:@_-")
       Class['port389::admin::service']
 
       if $::port389::enable_server_admin_ssl {
-        include port389::admin::ssl
 
         Exec["setup-ds-admin.pl_${title}"] ->
-        Class['port389::admin::ssl'] ->
+        class { 'port389::admin::ssl': service_name => $title } ->
         Class['port389::admin::service']
       }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -143,7 +143,7 @@ It must contain only alphanumeric characters and the following: #%:@_-")
         Exec["setup-ds-admin.pl_${title}"] ->
         class { 'port389::admin::ssl':
           service_name => $title,
-          admin_domain => $admin_domain
+          admin_domain => $admin_domain,
         } ->
         Class['port389::admin::service']
       }

--- a/templates/enable_admin_ssl.ldif.erb
+++ b/templates/enable_admin_ssl.ldif.erb
@@ -1,4 +1,4 @@
-dn: cn=slapd-ldap1,cn=389 Directory Server,cn=Server Group,cn=main.vm,ou=sdm.noao.edu,o=NetscapeRoot
+dn: cn=slapd-<%= @service_name %>,cn=389 Directory Server,cn=Server Group,cn=<%= scope['port389::full_machine_name'] %>,ou=<%= @admin_domain %>,o=NetscapeRoot
 changetype: modify
 replace: nsServerSecurity
 nsServerSecurity: on
@@ -6,7 +6,7 @@ nsServerSecurity: on
 replace: nsSecureServerPort
 nsSecureServerPort: <%= @ssl_server_port %>
 
-dn: cn=configuration,cn=admin-serv-main,cn=389 Administration Server,cn=Server Group,cn=main.vm,ou=sdm.noao.edu,o=NetscapeRoot
+dn: cn=configuration,cn=admin-serv-<%= @hostname %>,cn=389 Administration Server,cn=Server Group,cn=<%= scope['port389::full_machine_name'] %>,ou=<%= @admin_domain %>,o=NetscapeRoot
 changetype: modify
 replace: nsServerSecurity
 nsServerSecurity: on


### PR DESCRIPTION
I only had the chance to test on RHEL 6, but this should fix the problem when enabling ssl for the admin server.
