### PR TITLE
disable the use of sslv3 for secure connections

### DIFF
--- a/manifests/instance/ssl.pp
+++ b/manifests/instance/ssl.pp
@@ -57,7 +57,7 @@ define port389::instance::ssl (
   exec { "${name}-enable_ssl.ldif":
     path      => ['/bin', '/usr/bin'],
     command   => "ldapmodify ${ldap_connect} -f ${::port389::setup_dir}/enable_ssl.ldif",
-    unless    => "ldapsearch ${ldap_connect} -b cn=encryption,cn=config \"nsSSL3=on\" nsSSL3 | grep \"nsSSL3: on\"",
+    unless    => "ldapsearch ${ldap_connect} -b cn=config \"nsslapd-security=on\" nsslapd-security | grep \"nsslapd-security: on\"",
     logoutput => true,
     require   => [Class['openldap::client'], File['enable_ssl.ldif']],
   } ->

--- a/templates/enable_ssl.ldif.erb
+++ b/templates/enable_ssl.ldif.erb
@@ -1,8 +1,5 @@
 dn: cn=encryption,cn=config
 changetype: modify
-replace: nsSSL3
-nsSSL3: on
--
 replace: nsSSLClientAuth
 nsSSLClientAuth: allowed
 -


### PR DESCRIPTION
As SSLv3 is not recommended anymore and TLS is enabled by default.